### PR TITLE
Add encoding utf-8 for save_to_file

### DIFF
--- a/src/pyobsplot/obsplot.py
+++ b/src/pyobsplot/obsplot.py
@@ -294,5 +294,5 @@ class ObsplotJsdomCreator(ObsplotCreator):
             warnings.warn(
                 f"Output is HTML but file extension is '{extension}'", RuntimeWarning
             )
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(res.data)

--- a/tests/python/test_obsplot.py
+++ b/tests/python/test_obsplot.py
@@ -174,3 +174,15 @@ class TestInit:
             r.content.decode()
             == "Server error: Unexpected token h in JSON at position 1."
         )
+
+
+class TestSaveToFile:
+    def test_svg_with_negative_numbers(self, tmp_path, oj):
+        """If utf-8 isn't specified encoding a minus symbol raises 'charmap' codec can't encode character '\u2212'."""
+        oj = Obsplot(renderer="jsdom")
+        oj(
+            Plot.tickX(
+                [-1],
+            ),
+            path=tmp_path / "test.svg",
+        )


### PR DESCRIPTION
Stumbled on this when testing the new save_to_file functionality. Hope a pull request is okay! Feel free to make or suggest changes if it doesn't look quite right. 

When saving to SVG if utf-8 isn't specified encoding a minus symbol raises 'charmap' codec can't encode character '\u2212'.

