### PR TITLE
add light-html theme

### DIFF
--- a/src/pyobsplot/static/static-styles.css
+++ b/src/pyobsplot/static/static-styles.css
@@ -1,4 +1,9 @@
 /* css/styles.css */
+:root {
+  --sans-serif: -apple-system, BlinkMacSystemFont, "avenir next", avenir,
+    helvetica, "helvetica neue", ubuntu, roboto, noto, "segoe ui", arial,
+    sans-serif;
+}
 .pyobsplot-plot h2 {
   line-height: 28px;
   font-size: 20px;
@@ -22,6 +27,18 @@
   color: black;
   background-color: white;
 }
+.pyobsplot-plot.light-html svg,
+.pyobsplot-plot.light-html figure {
+  color: black;
+  background-color: white;
+}
+.pyobsplot-plot.light-html h2 {
+  font-family: var(--sans-serif)
+}
+.pyobsplot-plot.light-html h3 {
+  font-family: var(--sans-serif)
+}
+
 .pyobsplot-plot.dark svg,
 .pyobsplot-plot.dark figure {
   color: white;

--- a/src/pyobsplot/utils.py
+++ b/src/pyobsplot/utils.py
@@ -24,7 +24,7 @@ ALLOWED_DEFAULTS = [
 ]
 
 # Themes
-AVAILABLE_THEMES = ["light", "dark", "current"]
+AVAILABLE_THEMES = ["light", "dark", "current", "light-html"]
 DEFAULT_THEME = "light"
 
 # List of existing plot methods


### PR DESCRIPTION
What do you think of this? Probably showing my ignorance in the world of css, but adding a new theme achieves what I was after. The upstream issue of being able to set styles on the figure would of course allow you to achieve the same but where users want to export an image and expect it to look as it did in a jupyter notebook perhaps this is more friendly?

```
from pyobsplot import Obsplot, Plot
import polars as pl

op = Obsplot(theme="light-html")
penguins = pl.read_csv("https://github.com/juba/pyobsplot/raw/main/doc/data/penguins.csv")

op({
    "color": {"legend": True},
    "marginLeft": 80,
    "marginRight": 80,
    "x": {"inset": 20},
    "grid": True,
    "marks": [
        Plot.boxX(penguins, {
            "x": "body_mass_g", "fill": "island", "y": "island", "fy": "species"
        })
    ],
    "title": "Test title",
    "subtitle": "Test subtitle",
    "caption": "Test caption"
}, path= "out.html")
```
Before - 
![image](https://github.com/juba/pyobsplot/assets/51630653/2df627cd-c13a-4ac9-b523-ed53e2e6b9b2)
After - 
![image](https://github.com/juba/pyobsplot/assets/51630653/e0dce020-30bc-47bc-866d-794fb74dca13)

