### PR TITLE
Added typst renderer to support png/pdf/jpg/svg exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "polars>=0.20.0",
     "pyarrow==15.0.0",
     "requests",
+    "typst>=0.11.0",
+    "beautifulsoup4>=4.10.0",
+    "lxml>=5.0.0",
 ]
 
 [project.urls]

--- a/src/pyobsplot/obsplot.py
+++ b/src/pyobsplot/obsplot.py
@@ -383,7 +383,7 @@ class ObsplotTypstCreator(ObsplotJsdomCreator):
                     if "marginRight" in spec:
                         width += spec["marginRight"]
                 display(
-                    Image(filename=f.name, width=width, height=spec["height"] if "height" in spec else None)
+                    Image(data=f.read(), width=width, height=spec["height"] if "height" in spec else None)
                 )
         else:
             self.save_to_file(path, res)

--- a/src/pyobsplot/obsplot.py
+++ b/src/pyobsplot/obsplot.py
@@ -436,7 +436,7 @@ class ObsplotTypstCreator(ObsplotJsdomCreator):
                     )
                 swatches.append(new_swatch)
             for i, svg in enumerate(figure.find_all("svg", recursive=False)):
-                with open(f"{tmpdirname}/{stem}_{i}.svg", "w") as f:
+                with open(f"{tmpdirname}/{stem}_{i}.svg", "w", encoding = 'utf-8') as f:
                     f.write(ObsplotTypstCreator.shift_svg(str(svg)))
                 plots.append({"file": f"{stem}_{i}.svg", "width": svg.attrs["width"], "height": svg.attrs["height"]})
             max_width = max(int(svg["width"]) for svg in plots)

--- a/src/pyobsplot/obsplot.py
+++ b/src/pyobsplot/obsplot.py
@@ -329,7 +329,7 @@ class ObsplotJsdomCreator(ObsplotCreator):
 
 class ObsplotTypstCreator(ObsplotJsdomCreator):
     """
-    Jsdom renderer Creator class.
+    Typst renderer Creator class.
     """
 
     def __init__(
@@ -393,11 +393,9 @@ class ObsplotTypstCreator(ObsplotJsdomCreator):
             path.write(str(res.data))
             return
         extension = Path(path).suffix.lower()
-        if extension not in [".png", ".jpg", ".jpeg", ".svg", ".pdf"]:
-            warnings.warn(
-                "Output file extension should be one of 'png', 'jpg', 'jpeg', 'svg', or 'pdf'",
-                RuntimeWarning,
-                stacklevel=1,
+        if extension not in [".png", ".svg", ".pdf"]:
+            raise ValueError(
+                "Output file extension should be one of 'png', 'svg' or 'pdf'"
             )
         with open(path, "w", encoding="utf-8") as f:
             self.render_typst(str(res.data), f.name)

--- a/src/pyobsplot/static/template.typ
+++ b/src/pyobsplot/static/template.typ
@@ -1,0 +1,78 @@
+#let find-child(elem, tag) = {
+  elem.children
+    .find(e => "tag" in e and e.tag == tag)
+}
+
+#let encode-xml(elem) = {
+  if (type(elem) == "string") {
+    elem
+  } else if (type(elem) == "dictionary") {
+    "<" + elem.tag + elem.attrs.pairs().map(
+        v => " " + v.at(0) + "=\"" + v.at(1) + "\""
+    ).join("") + if (elem.tag == "svg") {" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\""} + ">" + elem.children.map(encode-xml).join("") + "</" + elem.tag + ">"
+  }
+}
+
+#let obsplot(
+    file,
+    margin: 4pt,
+    font: "SF Pro Display",
+    font-size: 10pt,
+) = {
+    let swatch-item(elem) = {
+        set align(horizon)
+        stack(
+            dir: ltr, 
+            spacing: .5em, 
+            image.decode(
+                encode-xml(elem.children.first()), 
+                width: 1pt * int(elem.children.first().attrs.width), 
+                height: 1pt * int(elem.children.first().attrs.width)
+            ),
+            text(elem.children.last())
+        )
+    }
+
+    let swatch(elem) = {
+        stack(
+            dir: ltr, 
+            spacing: 1em, 
+            ..elem.children.filter(e => e.tag == "span").map(swatch-item)
+        )
+    }
+
+    let html = xml(file)
+    let figure = html.first()
+    let title = find-child(figure, "h2")
+    let subtitle = find-child(figure, "h3")
+    let caption = find-child(figure, "figcaption")
+    let figuresvg = find-child(figure, "svg")
+    let figurewidth = int(figuresvg.attrs.width)
+
+    set text(
+        font: "SF Pro Display",
+        size: font-size,
+        fallback: false
+    )
+
+    set page(
+        width: 1pt*figurewidth + 2*margin,
+        height: auto,
+        margin: (x: margin, y: margin)
+    )
+
+    stack(
+        dir: ttb,
+        spacing: 1em,
+        heading(title.children.first(), level: 1),
+        if (subtitle != none) {
+            heading(subtitle.children.first(), level: 2)
+        },
+        v(2em),
+        ..figure.children.filter(e => e.tag == "div").map(swatch),
+        image.decode(encode-xml(figuresvg)),
+        if (caption != none) {
+            text(caption.children.first())
+        }
+    )
+}


### PR DESCRIPTION
This is a pull request addressing https://github.com/juba/pyobsplot/issues/23 

Supported output formats are 
- pdf 
- png
- svg (including title, caption etc)

### Example 

```
from pyobsplot import Obsplot, Plot
import polars as pl

penguins = pl.read_csv("https://github.com/juba/pyobsplot/raw/main/doc/data/penguins.csv")
op = Obsplot(renderer="typst", dpi=300, font="SF Pro Display", font_size=14, margin=4)

op({
    "color": {"legend": True},
    "marginLeft": 80,
    "marginRight": 80,
    "title": "Penguin body mass by island",
    "x": {"inset": 20},
    "grid": True,
    "marks": [
        Plot.boxX(penguins, {
            "x": "body_mass_g", "fill": "island", "y": "island", "fy": "species"
        })
    ]
})
```

results in 
![typst](https://github.com/juba/pyobsplot/assets/17571643/7dec58ee-47d1-45a9-81e1-d15f3c80728d)

### Writing to file 

```
op(spec, path="file.png")
```

saves the output to a file

### Issues 

- One minor issue is that some font needs to be installed on the system supporting glyphs like → (RIGHTWARDS ARROW', U+2192). I am using [SF Pro Display](https://developer.apple.com/fonts/) which is free. 
- I am not sure how to handle options. For my taste a global option like

```
op = Obsplot(renderer="typst", dpi=300, font="SF Pro Display", font_size=14, margin=4)
```

over something like 

```
op(spec, path="file.png", dpi=300, font="SF Pro Display", font_size=14, margin=4)
```
