### PR TITLE
Bug fix for continuous legends, support for format-options and pdf exports in Plot.plot

### DIFF
--- a/src/pyobsplot/js_modules.py
+++ b/src/pyobsplot/js_modules.py
@@ -22,6 +22,7 @@ class Plot:
         spec: dict,
         format: Literal["widget", "html", "svg", "png"] | None = None,  # noqa: A002
         path: str | None = None,
+        format_options: dict | None = None,
     ) -> ObsplotWidget | None:
         """
         Plot.plot static method. If called directly, create an ObsplotWidget
@@ -36,18 +37,22 @@ class Plot:
         path : str | io.StringIO | None, optional
             if provided, plot is saved to disk to an HTML file instead of displayed
             as a jupyter widget, by default None
+        format_options : dict, optional
+            default output format options for typst formatter. Currently
+            possible keys are 'font' (name of font family), 'scale' (font scaling)
+            and 'margin' (margin around the plot, e.g. '1in' or '10pt')
         """
         format_value = format
         if path is not None and not isinstance(path, io.StringIO):
             extension = Path(path).suffix.lower()[1:]
-            allowed_extensions = ["html", "svg", "pdf", "png"]
+            allowed_extensions = ["html", "svg", "pdf", "png", "pdf"]
             if extension not in allowed_extensions:
                 msg = f"Output file extension should be one of {allowed_extensions}"
                 raise ValueError(msg)
             format_value = format_value or extension
 
         format_value = format_value or _plot_format
-        op = Obsplot(format=format_value)  # type: ignore
+        op = Obsplot(format=format_value if format_value != "pdf" else "svg", format_options=format_options)  # type: ignore
         return op(spec, path=path)
 
 

--- a/src/pyobsplot/obsplot.py
+++ b/src/pyobsplot/obsplot.py
@@ -58,7 +58,7 @@ class Obsplot:
         format_options : dict, optional
             default output format options for typst formatter. Currently
             possible keys are 'font' (name of font family), 'scale' (font scaling)
-            and 'margin' (margin in pt around the plot)
+            and 'margin' (margin around the plot, e.g. '1in' or '10pt')
         debug : bool, optional
             activate debug mode, by default False
         renderer : str, optional
@@ -395,13 +395,16 @@ class ObsplotJsdomCreator:
                 )
                 if "margin" in options:
                     value = options["margin"]
-                    typst_content += f"margin: {value}pt,"
+                    typst_content += f"margin: {value},"
                 if "font" in options:
                     value = options["font"]
                     typst_content += f'font-family: "{value}",'
                 if "scale" in options:
                     value = options["scale"]
                     typst_content += f"scale: {value},"
+                if "legend-padding" in options:
+                    value = options["legend-padding"]
+                    typst_content += f"legend-padding: {value},"
                 typst_content += ")"
                 typst_file.write(typst_content)
 

--- a/src/pyobsplot/static/template.typ
+++ b/src/pyobsplot/static/template.typ
@@ -17,7 +17,8 @@
     file,
     margin: 10pt,
     font-family: ("San Francisco", "Segoe UI", "Noto Sans", "Roboto", "Cantarell", "Ubuntu", "Lucida Grande", "Arial"),
-    scale: 1
+    scale: 1,
+    legend-padding: 20,
 ) = {
 
     set text(
@@ -54,8 +55,15 @@
     let title = find-child(figure, "h2")
     let subtitle = find-child(figure, "h3")
     let caption = find-child(figure, "figcaption")
-    let figuresvg = find-child(figure, "svg")
-    let figurewidth = int(figuresvg.attrs.width)
+    let figuresvgs = figure.children.filter(e => "tag" in e and e.tag == "svg")
+    let legends = figuresvgs
+    .filter(svg => "ramp" in svg.attrs.class)
+    .map(svg => (..svg, attrs: (..svg.attrs,
+                                 width: str(int(svg.attrs.width) + 2*legend-padding), 
+                                 viewbox: "-"+str(legend-padding)+" 0 "+str(int(svg.attrs.width)+legend-padding)+" "+str(int(svg.attrs.height)))
+                                ))
+    let mainfigure = figuresvgs.find(svg => "ramp" not in svg.attrs.class)
+    let figurewidth = calc.max(..figuresvgs.map(svg => int(svg.attrs.width)))
 
     set page(
         width: 1in*figurewidth/dpi + 2*margin,
@@ -78,7 +86,8 @@
             v(1in * 8/dpi)
         },
         ..figure.children.filter(e => e.tag == "div").map(swatch),
-        image.decode(encode-xml(figuresvg)),
+        ..legends.map(svg => image.decode(encode-xml(svg), height: 1in * int(svg.attrs.height) / dpi)),
+        image.decode(encode-xml(mainfigure), height: 1in * int(mainfigure.attrs.height) / dpi),
         if (caption != none) {
             set text(size: 1in * 13/dpi, fill: rgb(85, 85, 85), weight: 500)
             text(caption.children.first())

--- a/src/pyobsplot/utils.py
+++ b/src/pyobsplot/utils.py
@@ -24,7 +24,7 @@ ALLOWED_DEFAULTS = [
 ]
 
 # Allowed format options
-ALLOWED_FORMAT_OPTIONS = ["font", "scale", "margin"]
+ALLOWED_FORMAT_OPTIONS = ["font", "scale", "margin", "legend-padding"]
 
 # Themes
 AVAILABLE_THEMES = ["light", "dark", "current"]


### PR DESCRIPTION
This is a follow to the previous pull request. 

- The main change is that the previous typst code failed for continuous legends (the output just contained the legend, not the plot), see the example below where the legend is displayed but the plot itself is missing
![test_bug](https://github.com/juba/pyobsplot/assets/17571643/72599265-0a38-4d8d-a223-f53c03af6559)

- For this there is some issue with the way Observable Plot generates legend `svg`'s. Basically some tick labels can extend beyond the `viewbox` which is ok in HTML, but gets trimmed in typst. To facilitate this I added a further option `legend-padding` which by default is set to `20pt`. Here is an example of the problem and how it looks with default padding. One could also have left and right padding separately but not sure it is worth the complexity.
![test_padding](https://github.com/juba/pyobsplot/assets/17571643/f843935f-d27f-489f-89f1-e323a811ed78)
![test_no_padding](https://github.com/juba/pyobsplot/assets/17571643/bb24af1b-dfe2-4f5a-8471-651dda1af550)

- I made a small change to enable `format-options` and `path="test.pdf"` in `Plot.plot`, I think both would be useful to have there? 

- I made a small change so that the `margin` option can be given with units (eg `12pt`, `1in`, etc) but maybe this is too complicated?

